### PR TITLE
terra bug patch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Suggests:
     knitr,
     testthat (>= 3.0.0),
     rmarkdown
-Depends: R (>= 4.0.0), terra
+Depends: R (>= 4.0.0), terra (>= 1.7.29)
 Config/testthat/edition: 3
 SystemRequirements: C++11
 NeedsCompilation: yes

--- a/R/ppm_data.R
+++ b/R/ppm_data.R
@@ -547,10 +547,10 @@ getCovariates <- function(pbxy, covariates=NULL, interpolation, coord, buffer.NA
     covars <- cbind(SiteID=pbxy[,"SiteID"],pbxy[,coord])
   } else {
     covars <- terra::extract(x = covariates,
-                             y = data.frame(X=as.numeric(pbxy[,coord[1]]),
-                                           Y=as.numeric(pbxy[,coord[2]])),
-                             method=interpolation,
-                             na.rm=TRUE)
+                             y = as.matrix(cbind(X=as.numeric(pbxy[,coord[1]]),
+                                                 Y=as.numeric(pbxy[,coord[2]]))),
+                             method=interpolation)#,
+                             # na.rm=TRUE) ## apparently na.rm doesn't work for matrix
     covars <- cbind(SiteID=pbxy[,"SiteID"],pbxy[,coord],covars)
   if(buffer.NA){
     if(any(!complete.cases(covars))){


### PR DESCRIPTION
Terra changed it's extract behaviour, so it didn't work for a data.frame, but did for a matrix.